### PR TITLE
Fix comment in WatcherFieldType

### DIFF
--- a/src/main/java/com/burningcode/jira/issue/customfields/impl/WatcherFieldType.java
+++ b/src/main/java/com/burningcode/jira/issue/customfields/impl/WatcherFieldType.java
@@ -178,7 +178,7 @@ public class WatcherFieldType extends MultiUserCFType {
     }
 
     /**
-     * Checks if a user the authenticated user has the "Manage Watcher List" permission.
+     * Checks if the authenticated user has the "Manage Watcher List" permission.
      *
      * @param issue The issue the user is trying to add watchers to.
      * @return True if has permissions, false otherwise.


### PR DESCRIPTION
## Summary
- fix documentation for watcher permission check

## Testing
- `mvn -q -DskipTests=false test` *(fails: could not resolve `jira-maven-plugin`)*

------
https://chatgpt.com/codex/tasks/task_b_6884b232049c8331ac13fa4e5df79f02