### PR TITLE
Fix watchers section path in plugin XML

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -50,7 +50,7 @@
 
 	<web-item key="watcherfieldSettingsLink"
 			i18n-name-key="watcherfield.settings.link.name"
-			section="admin_plugins_menu/watchers-sections"
+                        section="admin_plugins_menu/watchers-section"
 			weight="90">
         <description key="watcherfield.settings.link.desc" />
         <label key="watcherfield.settings.link.label" />


### PR DESCRIPTION
## Summary
- fix the web-item section path in `atlassian-plugin.xml`

## Testing
- `mvn -q test` *(fails: Failed to read artifact descriptor for com.atlassian.maven.plugins:jira-maven-plugin:jar:9.1.1)*

------
https://chatgpt.com/codex/tasks/task_b_6884b22976c48331826bbc1e4a03f9d4