### PR TITLE
Add WatcherFieldType unit test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,21 @@
             <version>1.1.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>com.atlassian.maven.plugins</groupId>

--- a/src/test/java/com/burningcode/jira/issue/customfields/impl/WatcherFieldTypeTest.java
+++ b/src/test/java/com/burningcode/jira/issue/customfields/impl/WatcherFieldTypeTest.java
@@ -1,0 +1,28 @@
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.atlassian.jira.issue.comparator.UserComparator;
+import com.atlassian.jira.user.ApplicationUser;
+
+public class WatcherFieldTypeTest {
+
+    @Test
+    public void testValuesEqualIgnoresOrder() {
+        WatcherFieldType type = Mockito.mock(WatcherFieldType.class, Mockito.CALLS_REAL_METHODS);
+
+        ApplicationUser user1 = Mockito.mock(ApplicationUser.class);
+        Mockito.when(user1.getName()).thenReturn("a");
+        ApplicationUser user2 = Mockito.mock(ApplicationUser.class);
+        Mockito.when(user2.getName()).thenReturn("b");
+
+        Collection<ApplicationUser> list1 = Arrays.asList(user1, user2);
+        Collection<ApplicationUser> list2 = Arrays.asList(user2, user1);
+
+        assertTrue(type.valuesEqual(list1, list2));
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit test for `WatcherFieldType.valuesEqual`
- include new test directory in `pom.xml`
- add JUnit and Mockito dependencies

## Testing
- `mvn -q test` *(fails: Unresolveable build extension)*

------
https://chatgpt.com/codex/tasks/task_b_6884b23690848331bbb85063b75f46d5