### PR TITLE
Fix typo in comment

### DIFF
--- a/src/main/java/com/burningcode/jira/issue/customfields/impl/WatcherFieldType.java
+++ b/src/main/java/com/burningcode/jira/issue/customfields/impl/WatcherFieldType.java
@@ -153,7 +153,7 @@ public class WatcherFieldType extends MultiUserCFType {
     }
 
     /**
-     * Checks to see if the issue can be edited.  It checks to see if the issue has been create, if it is
+     * Checks to see if the issue can be edited.  It checks to see if the issue has been created, if it is
      * editable, and if the authenticated user has permissions.
      *
      * @param issue The issue being edited.


### PR DESCRIPTION
## Summary
- fix typo in WatcherFieldType comment

## Testing
- `mvn -q test` *(fails: could not resolve `jira-maven-plugin`)*

------
https://chatgpt.com/codex/tasks/task_b_6884b22267508331ab73ee29118ac800